### PR TITLE
Develop

### DIFF
--- a/Code/package.json
+++ b/Code/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "start": "node src/web/app.js",
     "pretest": "jshint ./test/** ./src/**",
-    "test": "istanbul cover _mocha --check-leaks ./test/unit/** ./test/functional/** ./test/integration/**",
+    "test": "istanbul cover _mocha --check-leaks -- ./test/unit/** ./test/integration/**",
     "unit-test": "mocha --check-leaks ./test/unit/**",
-    "cover": "istanbul cover _mocha -- ./test/unit/** ./test/functional/**",
+    "cover": "istanbul cover _mocha -- ./test/unit/** ./test/integration/**",
     "docs": "jsdoc -r -R README.md -d ./jsdoc ./src"
   },
   "dependencies": {

--- a/Code/src/core/adapters/persistence/cloudant-bolo-repository.js
+++ b/Code/src/core/adapters/persistence/cloudant-bolo-repository.js
@@ -270,17 +270,16 @@ CloudantBoloRepository.prototype.searchBolos = function (limit,query_string,book
             return boloFromCloudant( row.doc );
         });
         var flag = true;
-        while(flag ===true) {
+        while(flag === true) {
             flag = false;
-            for (var i = 0; i < bolos.length-1; i++) {
-
-                var date_one = bolos[i].createdOn;
-                var date_two = bolos[i + 1].createdOn;
+            for (var j = 0; j < bolos.length-1; j++) {
+                var date_one = bolos[j].createdOn;
+                var date_two = bolos[j + 1].createdOn;
                 var order = date_one > date_two ? 1 : date_one < date_two ? -1 : 0;
                 if (order === -1) {
-                    var swap = bolos[i + 1];
-                    bolos[i + 1] = bolos[i];
-                    bolos[i] = swap;
+                    var swap = bolos[j + 1];
+                    bolos[j + 1] = bolos[j];
+                    bolos[j] = swap;
                     flag = true;
                 }
             }

--- a/Code/src/core/lib/cloudant-promise/index.js
+++ b/Code/src/core/lib/cloudant-promise/index.js
@@ -94,8 +94,7 @@ db_wrapper.search = function ( designname, searchname, params ) {
     return new Promise( function ( resolve, reject ) {
         context.db.search( designname, searchname, params, function ( err, body ) {
 
-            if ( !err ) {
-                resolve( body )};
+            if ( !err ) resolve( body );
             reject( err );
         });
     });

--- a/Code/src/web/routes/bolos.js
+++ b/Code/src/web/routes/bolos.js
@@ -138,7 +138,7 @@ router.get( '/bolo/archive', function ( req, res, next ) {
 });
 
 
-router.get( '/bolo/search/results', function ( req, res ) {
+router.get( '/bolo/search/results', function ( req, res, next ) {
 
     console.log(req.query.bookmark );
     var query_string = req.query.valid;
@@ -162,8 +162,7 @@ router.get( '/bolo/search/results', function ( req, res ) {
 
         data.bolos = results.bolos;
         res.render( 'bolo-search-results', data );
-    })
-        .catch( function ( error ) {
+    }).catch( function ( error ) {
         next( error );
     });
 
@@ -188,7 +187,7 @@ router.post( '/bolo/search', function ( req, res, next ) {
         var MATCH_EXPR = ' OR ';
         var expression = false;
 
-        if (query_obj['matchFields'] === "on")
+        if ( "on" === query_obj.matchFields )
         {
             MATCH_EXPR = ' AND ';
         }


### PR DESCRIPTION
Fix errors with running `npm test`.

Note that using `npm test` is a comprehensive testing running script.  Normal usage for a testing workflow should take advantage of the mocha test runner _watch_ feature.

Open a new terminal window and change into your project directory.  Make sure mocha is installed globally (`npm install -g mocha`) then type `mocha --watch ./test/unit`.  This will run unit tests and re-run whenever a module with a unit test is changed and saved.
